### PR TITLE
Updated for iPhone 14 Pro launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Please read this guide before creating a new issue, thanks!
 
 Most 2D games could be run at 60fps on A14-based devices. 
 
-However, the performance of 3D games varies for each game, an A15-based device could run most 3D games at nearly full speed.
+However, the performance of 3D games varies for each game, an A15- and A16-based device could run most 3D games at nearly full speed.
 
 By default, 30FPS limit mode is enabled. It is strongly recommended to enable this mode on A14-based devices (or earlier) to protect battery life and keep the temperature comfortable for playing. 
 
-On A15-based devices, this mode could be disabled if you want to have a smoother experience.
+On A15- and A16-based devices, this mode could be disabled if you want to have a smoother experience.
 
 # Control
 


### PR DESCRIPTION
iPhone 14 Pro (also known as iPhone15,2) was launched on September 7, 2022 and contains an Apple A16 Bionic. Based on a 4nm process and running at 3.46 GHz, Geekbench 5 showed that A16 Bionic was 17% faster than A15 Bionic found in last year’s iPhone 13 Pro.

Source: https://www.macrumors.com/2022/09/09/a16-iphone-14-pro-benchmark/

![iphone-14-pro-max-geekbench](https://user-images.githubusercontent.com/98016194/192004459-21248c84-7e31-4875-b125-0dd14c7550ae.jpg)