### PR TITLE
Add CMakeLists.txt and build instructions

### DIFF
--- a/desmume/wasm-port/CMakeLists.txt
+++ b/desmume/wasm-port/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(nds ../src/wifi.cpp ../src/armcpu.cpp  ../src/cp15.cpp  ../src/firmware.cpp  ../src/MMU.cpp  ../src/readwrite.cpp  ../src/SPU.cpp  ../src/arm_instructions.cpp  ../src/Database.cpp  ../src/gfx3d.cpp  ../src/movie.cpp  ../src/render3D.cpp  ../src/texcache.cpp  ../src/arm_jit.cpp  ../src/debug.cpp  ../src/GPU.cpp  ../src/NDSSystem.cpp  ../src/ROMReader.cpp  ../src/thumb_instructions.cpp  ../src/bios.cpp  ../src/driver.cpp   ../src/rtc.cpp  ../src/version.cpp  ../src/cheatSystem.cpp  ../src/emufile.cpp  ../src/matrix.cpp  ../src/saves.cpp  ../src/commandline.cpp  ../src/encrypt.cpp  ../src/mc.cpp  ../src/path.cpp  ../src/slot1.cpp  ../src/common.cpp  ../src/FIFO.cpp ../src/mic.cpp  ../src/rasterize.cpp  ../src/slot2.cpp)
+
+target_sources(nds PRIVATE ../src/utils/xstring.cpp ../src/metaspu/metaspu.cpp ../src/utils/guid.cpp ../src/libretro-common/encodings/encoding_utf.c ../src/addons/slot1_none.cpp ../src/addons/slot1_retail_auto.cpp ../src/addons/slot1_retail_nand.cpp  ../src/addons/slot1_retail_mcrom.cpp  ../src/addons/slot1comp_mc.cpp ../src/addons/slot2_none.cpp ../src/utils/colorspacehandler/colorspacehandler.cpp ../src/addons/slot1comp_rom.cpp ../src/addons/slot1comp_protocol.cpp ../src/utils/datetime.cpp ../src/utils/decrypt/decrypt.cpp ../src/utils/decrypt/header.cpp  ../src/filter/xbrz.cpp ../src/filter/deposterize.cpp) 
+
+target_sources(nds PRIVATE main.cpp)
+
+target_compile_definitions(nds PRIVATE HAVE_LIBZ=1)
+target_include_directories(nds PRIVATE ../src ../src/libretro-common/include ../src/utils ../src/metaspu .)
+target_compile_options(nds PRIVATE -flto -O3  -sUSE_ZLIB=1)
+target_link_options(nds PRIVATE -flto -O3 --emit-symbol-map -lz -sEXPORTED_FUNCTIONS=['_savGetPointer','_savUpdateChangeFlag','_savGetSize','_fillAudioBuffer','_runFrame','_main','_getSymbol','_prepareRomBuffer','_loadROM','_setSampleRate','_emuSetOpt']  -sEXPORT_ALL=1 -sTOTAL_MEMORY=629145600 -sLLD_REPORT_UNDEFINED)

--- a/desmume/wasm-port/README.md
+++ b/desmume/wasm-port/README.md
@@ -1,8 +1,24 @@
 # wasm-port
 
-Latest HTML/JS/CSS source code is hosted on https://ds.44670.org .
+Latest HTML/JS/CSS source code is hosted on <https://ds.44670.org>.
 
-You may need a https-enabled web server to run the code.
+`nds.js` and `nds.wasm` files are built from this repo, with Emscripten.
 
-nds.js, nds.wasm files are built from this repo, with Emscripten.
+## Building from source
 
+Ensure that the CMake and Emscripten SDKs are installed on your system, and that the `emmake`, `cmake` and `make` (or equivalent for your system) commands are available.
+
+In the current directory (`desmume-wasm/desmume/wasm-port/`), run:
+
+1. `emmake cmake .` (append `-DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES=Release` for a release build, meaning smaller files)
+2. `emmake make` (append `-j$(nproc --all)` to build with multiple threads)
+
+You should get 2 runtime files: `nds` and `nds.wasm`.
+
+### Get the webapp working
+
+To get a working website, you need to download the external assets. You can use the `WebAssets.txt` list file, for example with wget: `for i in $(cat ./WebAssets.txt); do wget "https://ds.44670.org/$i"; done;`. Preferably run this in a clean folder without all the build files.
+
+Now, you can move the `nds` and `nds.wasm` files built previously to `build/nds.js` and `build/nds.wasm` in the folder containing the downloaded web assets.
+
+To run the app, serve the files from at least an HTTP web server for basic functionality, and HTTPS (due to service workers requirements) if you want the app to also work as an installable PWA.

--- a/desmume/wasm-port/WebAssets.txt
+++ b/desmume/wasm-port/WebAssets.txt
@@ -1,0 +1,9 @@
+app.js
+dark.css
+favicon.ico
+icon.png
+index.html
+localforage.js
+manifest.json
+pako.min.js
+sw.js


### PR DESCRIPTION
Added the missing CMakeLists.txt (updated to include exports of the previously missing functions), and added more detailed build instructions to the README.